### PR TITLE
Add attranslate to general

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A curated list of awesome i18n resources
 * [W3C Internationalization overview](http://www.w3.org/standards/webdesign/i18n)
 * [W3C Internationalization Activity homepage](http://www.w3.org/International/)
 * [GNU gettext](http://www.gnu.org/software/gettext/) A very popular tool for adding native language support to applications
+* [attranslate](https://github.com/fkirc/attranslate) Semi-automated translation for JSON, YAML, PO/POT and other file-formats
 
 ## JavaScript
 


### PR DESCRIPTION
Hi,

I felt that the i18n-ecosystem is still lacking tools for file-synchronization, which is why I wrote `attranslate`: https://github.com/fkirc/attranslate

I added it to the "general section" because it works for JavaScript, Ruby, Gettext and others.